### PR TITLE
Add copy bit at the end of the output just when required

### DIFF
--- a/lib/byteboozer2/cruncher.rb
+++ b/lib/byteboozer2/cruncher.rb
@@ -640,7 +640,7 @@ module ByteBoozer2
         max_diff = i - @put if i - @put > max_diff
       end
 
-      wbit(1)
+      wbit(1) if need_copy_bit
       wlength(0xff)
       wflush
 


### PR DESCRIPTION
The issue about the presence of an extra copy bit at the end of a compressed file is pretty much unharmful unless crunched files are linked together. The issue becomes evident when the last data bit of the 0xFF value overflows into an extra byte (0x80) due to a previously written copy bit that should not be there: the decruncher will therefore not fetch the extra byte to extract the single data bit that’s stored in it because it will have already read the spurious copy bit instead.